### PR TITLE
Add mobile UI shell under /new/ (non-destructive)

### DIFF
--- a/docs/new-ui-preview.md
+++ b/docs/new-ui-preview.md
@@ -1,0 +1,13 @@
+# New UI preview (non-destructive)
+
+This PR adds a self-contained mobile UI shell under `/new/*` without changing existing routes/layouts/hooks.
+
+Preview after `npm run dev`:
+
+- `/new/explore`
+- `/new/organizers`
+- `/new/map`
+- `/new/wallet`
+- `/new/more`
+
+No dependencies added. All styles are scoped to `.newui` to avoid conflicts.

--- a/src/lib/newui/components/CategoryChips.svelte
+++ b/src/lib/newui/components/CategoryChips.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  export let items: { label: string; icon?: string }[] = [];
+</script>
+
+<div class="scroll-x" style="padding-top:10px">
+  {#each items as it}
+    <div
+      class="card"
+      style="border-radius:14px;padding:10px 12px;display:flex;flex-direction:column;align-items:center;min-width:90px;background:var(--chip)"
+    >
+      <div style="width:28px;height:28px;color:var(--text)">
+        {@html it.icon ?? "🎉"}
+      </div>
+      <div class="small" style="margin-top:6px;color:var(--text)">
+        {it.label}
+      </div>
+    </div>
+  {/each}
+</div>

--- a/src/lib/newui/components/EventCard.svelte
+++ b/src/lib/newui/components/EventCard.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  export let title = "Event title";
+  export let subtitle = "Venue • City";
+  export let date = "14 Dec";
+  export let image = "https://picsum.photos/seed/event/600/400";
+  export let color = "#5C0D2A"; // band color
+</script>
+
+<div class="card" style="min-width:260px">
+  <div style="position:relative">
+    <img
+      src={image}
+      alt={title}
+      style="width:100%;height:160px;object-fit:cover"
+    />
+    <div style="position:absolute;right:10px;top:10px">
+      <span class="badge" style="background:var(--bg-elev)">{date}</span>
+    </div>
+    <div
+      style="position:absolute;left:0;right:0;bottom:0;height:50px;background:{color};opacity:.9;border-bottom-left-radius:20px;border-bottom-right-radius:20px"
+    ></div>
+  </div>
+  <div class="card-pad">
+    <div style="font-weight:800;letter-spacing:.3px">{title}</div>
+    <div class="subtitle" style="margin-top:4px">{subtitle}</div>
+  </div>
+</div>

--- a/src/lib/newui/components/OrganizerCard.svelte
+++ b/src/lib/newui/components/OrganizerCard.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  export let title = "Organizer";
+  export let image = "https://picsum.photos/seed/org/400/400";
+</script>
+
+<div class="card" style="overflow:hidden">
+  <img
+    src={image}
+    alt={title}
+    style="width:100%;aspect-ratio:1/1;object-fit:cover"
+  />
+  <div class="card-pad" style="padding:10px 8px">
+    <div style="font-weight:600">{title}</div>
+  </div>
+</div>

--- a/src/lib/newui/components/SearchBar.svelte
+++ b/src/lib/newui/components/SearchBar.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  export let placeholder = "Where to ?";
+</script>
+
+<div class="row" style="gap:10px">
+  <div
+    style="flex:1;display:flex;align-items:center;gap:10px;background:var(--chip);border:1px solid var(--stroke);border-radius:999px;padding:10px 14px;"
+  >
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      ><circle cx="11" cy="11" r="7" stroke-width="2" /><path
+        d="M20 20l-3.5-3.5"
+        stroke-width="2"
+      /></svg
+    >
+    <input class="input" {placeholder} />
+  </div>
+  <button class="btn icon" title="Filters">
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      ><path
+        d="M4 6h16M7 12h10M10 18h4"
+        stroke-width="2"
+        stroke-linecap="round"
+      /></svg
+    >
+  </button>
+</div>

--- a/src/lib/newui/components/SectionHeader.svelte
+++ b/src/lib/newui/components/SectionHeader.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  export let title = "";
+  export let href: string | null = null;
+</script>
+
+<div class="spread container" style="margin-top:var(--space-6)">
+  <h2 class="section-title" style="margin:0">{title}</h2>
+  {#if href}<a class="small" {href} style="color:var(--text)">View All</a>{/if}
+</div>

--- a/src/lib/newui/components/TabBar.svelte
+++ b/src/lib/newui/components/TabBar.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import { page } from "$app/stores";
+  $: path = $page.url.pathname;
+  const is = (p: string) => path === p;
+  export const icons = {
+    search: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="11" cy="11" r="7" stroke-width="2"/><path d="M20 20l-3.5-3.5" stroke-width="2"/></svg>`,
+    org: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="7" width="18" height="13" rx="2" stroke-width="2"/><path d="M7 7V4h10v3" stroke-width="2"/></svg>`,
+    globe: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="10" stroke-width="2"/><path d="M2 12h20M12 2c3 4 3 16 0 20M12 2c-3 4-3 16 0 20" stroke-width="2"/></svg>`,
+    wallet: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="7" width="18" height="12" rx="2" stroke-width="2"/><path d="M15 11h4v4h-4z" stroke-width="2"/></svg>`,
+    user: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="8" r="4" stroke-width="2"/><path d="M4 20c2-4 14-4 16 0" stroke-width="2"/></svg>`,
+  };
+</script>
+
+<nav class="tabbar">
+  <a class="tab {is('/new/explore') ? 'active' : ''}" href="/new/explore">
+    {@html icons.search}<span>Explore</span>
+  </a>
+  <a class="tab {is('/new/organizers') ? 'active' : ''}" href="/new/organizers">
+    {@html icons.org}<span>Organizers</span>
+  </a>
+  <a class="tab {is('/new/map') ? 'active' : ''}" href="/new/map">
+    {@html icons.globe}<span>Map</span>
+  </a>
+  <a class="tab {is('/new/wallet') ? 'active' : ''}" href="/new/wallet">
+    {@html icons.wallet}<span>Wallet</span>
+  </a>
+  <a class="tab {is('/new/more') ? 'active' : ''}" href="/new/more">
+    {@html icons.user}<span>More</span>
+  </a>
+</nav>

--- a/src/lib/styles/newui.css
+++ b/src/lib/styles/newui.css
@@ -1,0 +1,160 @@
+/* Scoped under .newui to avoid leaking into the rest of the app */
+.newui {
+  --radius-sm: 10px;
+  --radius-md: 16px;
+  --radius-lg: 22px;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-7: 28px;
+  --space-8: 32px;
+
+  --font-ui:
+    system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans,
+    "Helvetica Neue", Arial;
+  --shadow-1: 0 1px 2px rgba(0, 0, 0, 0.25);
+  --accent: #f39c28; /* orange */
+  --accent-press: #ce7e16;
+
+  /* Dark theme tokens */
+  --bg: #0c0c0e;
+  --bg-elev: #141417;
+  --text: #f3f3f3;
+  --text-dim: #c8c8c8;
+  --chip: #1c1c21;
+  --card: #17171b;
+  --stroke: #27272f;
+
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100dvh;
+}
+
+/* Utility classes (scoped) */
+.newui .container {
+  padding: 0 var(--space-5);
+}
+.newui .row {
+  display: flex;
+  gap: var(--space-4);
+  align-items: center;
+}
+.newui .spread {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.newui .section-title {
+  font-weight: 700;
+  font-size: 20px;
+  margin: var(--space-6) 0 var(--space-3);
+}
+.newui .badge {
+  background: var(--chip);
+  color: var(--text);
+  padding: 4px 8px;
+  border-radius: 999px;
+  font-size: 12px;
+  border: 1px solid var(--stroke);
+}
+.newui .scroll-x {
+  display: flex;
+  gap: 12px;
+  overflow-x: auto;
+  padding-bottom: 8px;
+}
+.newui .scroll-x::-webkit-scrollbar {
+  display: none;
+}
+.newui .small {
+  font-size: 12px;
+  color: var(--text-dim);
+}
+.newui .subtitle {
+  color: var(--text-dim);
+  font-size: 14px;
+}
+
+/* Buttons & inputs */
+.newui .btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--accent);
+  color: #111;
+  padding: 10px 14px;
+  border-radius: 999px;
+  border: none;
+  box-shadow: var(--shadow-1);
+  font-weight: 600;
+  cursor: pointer;
+}
+.newui .btn:active {
+  background: var(--accent-press);
+}
+.newui .btn.icon {
+  width: 40px;
+  height: 40px;
+  justify-content: center;
+  border-radius: 12px;
+  background: var(--chip);
+  color: var(--text);
+  border: 1px solid var(--stroke);
+}
+.newui .input {
+  appearance: none;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--text);
+  width: 100%;
+}
+
+/* Cards */
+.newui .card {
+  background: var(--card);
+  border: 1px solid var(--stroke);
+  border-radius: 20px;
+  overflow: hidden;
+  box-shadow: var(--shadow-1);
+}
+.newui .card-pad {
+  padding: 12px;
+}
+
+/* Tab bar (fixed) */
+.newui .tabbar {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: var(--bg-elev);
+  border-top: 1px solid var(--stroke);
+  display: flex;
+  justify-content: space-around;
+  padding: 8px 6px calc(env(safe-area-inset-bottom) + 6px);
+  z-index: 50;
+}
+.newui .tab {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--text-dim);
+}
+.newui .tab.active {
+  color: var(--accent);
+}
+.newui .tab svg {
+  width: 22px;
+  height: 22px;
+}
+
+/* Keep page content above tab bar */
+.newui .main {
+  padding-bottom: 84px;
+}

--- a/src/routes/new/+layout.svelte
+++ b/src/routes/new/+layout.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import "$lib/styles/newui.css";
+  import TabBar from "$lib/newui/components/TabBar.svelte";
+  export let data;
+</script>
+
+<div class="newui">
+  <div class="main">
+    <slot />
+  </div>
+  <TabBar />
+</div>

--- a/src/routes/new/explore/+page.svelte
+++ b/src/routes/new/explore/+page.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+  import SearchBar from "$lib/newui/components/SearchBar.svelte";
+  import CategoryChips from "$lib/newui/components/CategoryChips.svelte";
+  import EventCard from "$lib/newui/components/EventCard.svelte";
+  import SectionHeader from "$lib/newui/components/SectionHeader.svelte";
+
+  const chips = [
+    { label: "Free Events" },
+    { label: "Rock" },
+    { label: "Festival" },
+    { label: "Nightlife" },
+    { label: "Live Performance" },
+  ];
+</script>
+
+<div class="container" style="padding-top:24px">
+  <h1 style="font-weight:800;letter-spacing:.4px">EUFORIA</h1>
+  <div style="height:14px"></div>
+  <SearchBar />
+  <div style="height:18px"></div>
+  <CategoryChips items={chips} />
+</div>
+
+<div class="container" style="margin-top:18px">
+  <div class="card" style="overflow:hidden">
+    <div style="position:relative">
+      <img
+        src="https://picsum.photos/seed/hero/1200/800"
+        alt="Hero"
+        style="width:100%;aspect-ratio:16/9;object-fit:cover"
+      />
+      <div style="position:absolute;inset:0;display:flex;align-items:flex-end">
+        <div style="width:100%;height:68px;background:#5C0D2A;opacity:.9"></div>
+      </div>
+      <div style="position:absolute;bottom:14px;left:14px;font-weight:800">
+        JASNA ZLOKIĆ @ PORAT
+      </div>
+      <div style="position:absolute;top:10px;right:10px">
+        <span class="badge">14 Dec</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<SectionHeader title="This Weekend Events" href="/new/explore" />
+
+<div class="scroll-x container">
+  <EventCard
+    title="The Garden..."
+    subtitle="The Garden Bre..."
+    date="16 Mar"
+    image="https://picsum.photos/seed/a/600/400"
+  />
+  <EventCard
+    title="Brunch & lu..."
+    subtitle="Maredo Zagreb"
+    date="31 May"
+    image="https://picsum.photos/seed/b/600/400"
+  />
+  <EventCard
+    title="Feeling..."
+    subtitle="SquareOne"
+    date="02 Jun"
+    image="https://picsum.photos/seed/c/600/400"
+  />
+</div>
+
+<SectionHeader title="Live Performance" href="/new/explore" />
+<div class="scroll-x container">
+  <EventCard
+    title="JASNA ZLOKI..."
+    subtitle="Porat Club Split"
+    date="14 Dec"
+    image="https://picsum.photos/seed/d/600/400"
+  />
+  <EventCard
+    title="Acoustic Eve"
+    subtitle="Cafe Bar XX"
+    date="18 Dec"
+    image="https://picsum.photos/seed/e/600/400"
+  />
+</div>

--- a/src/routes/new/map/+page.svelte
+++ b/src/routes/new/map/+page.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import SearchBar from "$lib/newui/components/SearchBar.svelte";
+  import CategoryChips from "$lib/newui/components/CategoryChips.svelte";
+  const chips = [
+    { label: "Free Events" },
+    { label: "Nightclub" },
+    { label: "Bar" },
+    { label: "Pub" },
+    { label: "Rooftop" },
+    { label: "Lounge" },
+  ];
+</script>
+
+<div class="container" style="padding-top:24px">
+  <SearchBar />
+  <div style="height:10px"></div>
+  <CategoryChips items={chips} />
+</div>
+
+<div class="container" style="margin-top:10px">
+  <div
+    class="card"
+    style="height:60vh; border-radius:16px; overflow:hidden; position:relative"
+  >
+    <!-- Replace this container with actual MapLibre/Google Maps later -->
+    <div
+      style="position:absolute;inset:0;background:linear-gradient(180deg,#0f0f13,#121216)"
+    ></div>
+    <div style="position:absolute;left:16px;bottom:16px" class="badge">
+      Map placeholder
+    </div>
+  </div>
+</div>

--- a/src/routes/new/more/+page.svelte
+++ b/src/routes/new/more/+page.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  let dark = true;
+  if (typeof window !== "undefined") {
+    dark = (localStorage.getItem("newui-theme") ?? "dark") !== "light";
+    document.documentElement.toggleAttribute("data-newui-dark", dark);
+  }
+  function toggleTheme() {
+    dark = !dark;
+    localStorage.setItem("newui-theme", dark ? "dark" : "light");
+    document.documentElement.toggleAttribute("data-newui-dark", dark);
+  }
+</script>
+
+<div class="container" style="padding-top:24px">
+  <h1 style="font-weight:800">Account</h1>
+</div>
+
+<div class="container" style="margin-top:16px">
+  <div class="card" style="padding:14px;border-radius:16px">
+    <div class="row spread" style="padding:10px 6px">
+      <div>Profile</div>
+      <div>›</div>
+    </div>
+    <hr />
+    <div class="row spread" style="padding:10px 6px">
+      <div>Liked organizations</div>
+      <div>›</div>
+    </div>
+    <hr />
+    <div class="row spread" style="padding:10px 6px">
+      <div>My events</div>
+      <div>›</div>
+    </div>
+    <hr />
+    <div class="row spread" style="padding:10px 6px">
+      <div>Select theme mode</div>
+      <label style="display:inline-flex;align-items:center;gap:8px">
+        <input type="checkbox" on:change={toggleTheme} checked={dark} />
+      </label>
+    </div>
+  </div>
+</div>

--- a/src/routes/new/organizers/+page.svelte
+++ b/src/routes/new/organizers/+page.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import SearchBar from "$lib/newui/components/SearchBar.svelte";
+  import OrganizerCard from "$lib/newui/components/OrganizerCard.svelte";
+</script>
+
+<div class="container" style="padding-top:24px">
+  <h1 style="font-weight:800">Organizers</h1>
+  <div style="height:14px"></div>
+  <SearchBar placeholder="Search organizer" />
+</div>
+
+<div
+  class="container"
+  style="margin-top:16px;display:grid;grid-template-columns:1fr 1fr;gap:14px"
+>
+  <OrganizerCard
+    title="Osjećaj"
+    image="https://picsum.photos/seed/o1/600/600"
+  />
+  <OrganizerCard
+    title="Like Zadar"
+    image="https://picsum.photos/seed/o2/600/600"
+  />
+  <OrganizerCard
+    title="Zagreb Beer Fest"
+    image="https://picsum.photos/seed/o3/600/600"
+  />
+  <OrganizerCard
+    title="Zadar Wine Festival"
+    image="https://picsum.photos/seed/o4/600/600"
+  />
+</div>

--- a/src/routes/new/wallet/+page.svelte
+++ b/src/routes/new/wallet/+page.svelte
@@ -1,0 +1,4 @@
+<div class="container" style="padding-top:24px">
+  <h1 style="font-weight:800">Wallet</h1>
+  <p class="subtitle">Tickets & passes will appear here.</p>
+</div>


### PR DESCRIPTION
## Summary
- add dark-themed new UI components and styles scoped under `.newui`
- create `/new/*` routes with tab bar, search, organizers, map, wallet, and settings pages
- document how to preview the new shell

## Testing
- `API_BASE_URL=http://localhost pnpm test` *(fails: browserType.launch: Executable doesn't exist at ... run `pnpm exec playwright install`)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8d63e11f88324b779a4c58f6b5b61